### PR TITLE
doc(release-2020-10): add link to editor customization for includes

### DIFF
--- a/releases/release-2020-10.md
+++ b/releases/release-2020-10.md
@@ -217,10 +217,10 @@ References:
 
 ## Customise Editor UI with Vue for Doc Includes :gift:
 
-Implement a [custom Editor UI - TODO Beni](TODO Beni) for doc-includes with Vue.
+Implement a [custom Editor UI](https://docs.livingdocs.io/reference-docs/includes/editor_customization) for doc-includes with Vue.
 
 References:
-  * [Documentation (custom Editor UI - TODO Beni)](TODO Beni)
+  * [Documentation (custom Editor UI)](https://docs.livingdocs.io/reference-docs/includes/editor_customization)
   * [Documentation (Twitter Example)](https://github.com/livingdocsIO/livingdocs/pull/312)
   * [Documentation (doc-include)](https://docs.livingdocs.io/evaluation-guide/intro#summary-of-a-doc-include)
   * [Editor PR](https://github.com/livingdocsIO/livingdocs-editor/pull/3768)


### PR DESCRIPTION
This adds the link to the docs. Please merge only after this PR is merged: https://github.com/livingdocsIO/livingdocs/pull/336